### PR TITLE
docker: reduce images size

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,8 +1,7 @@
-# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-# Alpine is chosen for its small footprint
-# compared to Ubuntu
-FROM docker.io/library/golang:1.19.5-alpine
+FROM docker.io/library/golang:1.19.5-alpine as builder
 
 WORKDIR /app
 
@@ -15,5 +14,8 @@ RUN go mod download
 COPY *.go ./
 RUN go build -o /opi-security-client
 
+# second stage to reduce image size
+FROM alpine:3.17
+COPY --from=builder /opi-security-client /
 EXPOSE 50051
 CMD [ "/opi-security-client" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,13 +51,16 @@ services:
       - internet
       - intranet
     command: /opi-vici-bridge -port=50151
+    healthcheck:
+      test: grpcurl -plaintext localhost:50151 list || exit 1
 
   opi-security-client:
     build:
       context: client
     network_mode: service:vpn-server
     depends_on:
-      - opi-security-server
+      opi-security-server:
+        condition: service_healthy
     command: /opi-security-client -addr=opi-security-server:50151 -pingaddr=10.3.0.1
 
 networks:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,8 +1,7 @@
-# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-# Alpine is chosen for its small footprint
-# compared to Ubuntu
-FROM docker.io/library/golang:1.19.5-alpine
+FROM docker.io/library/golang:1.19.5-alpine as builder
 
 WORKDIR /app
 
@@ -15,5 +14,10 @@ RUN go mod download
 COPY *.go ./
 RUN go build -o /opi-vici-bridge
 
+# second stage to reduce image size
+FROM alpine:3.17
+COPY --from=builder /opi-vici-bridge /
+COPY --from=docker.io/fullstorydev/grpcurl:v1.8.7-alpine /bin/grpcurl /usr/local/bin/
 EXPOSE 50051
-CMD [ "/opi-vici-bridge" ]
+CMD [ "/opi-vici-bridge", "-port=50051" ]
+HEALTHCHECK CMD grpcurl -plaintext localhost:50051 list || exit 1


### PR DESCRIPTION
- reduce for server
- reduce for client
- add healthcheck

By introducing multi-stage build
And switching to alpine
And using grpcurl from docker

x10 size reduction !

```
$ docker images | grep security
opi-security-client                      main           9c9035988961   13 minutes ago      20.4MB
opi-security-server                      main           f7912c84ac69   14 minutes ago      50.1MB
ghcr.io/opiproject/opi-security-server   main           5f80aac46c87   12 hours ago        596MB
ghcr.io/opiproject/opi-security-client   main           4383c5225bdd   12 hours ago        598MB

```

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
