### PR TITLE
chore(deps): update strongswanx509/strongswan docker tag to v5.9.13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3.7'
 
 services:
   vpn-server:
-    image: strongx509/strongswan:5.9.11
+    image: strongx509/strongswan:5.9.13
     cap_add:
       - NET_ADMIN
       - SYS_ADMIN
@@ -24,7 +24,7 @@ services:
     command: './charon'
 
   vpn-client:
-    image: strongx509/strongswan:5.9.11
+    image: strongx509/strongswan:5.9.13
     depends_on:
       - vpn-server
     cap_add:


### PR DESCRIPTION
Fix for [PR#269](https://github.com/opiproject/opi-strongswan-bridge/pull/269) tested in local environment.  Tests seem to intermittently error on address in use.